### PR TITLE
Fix Storage Unit exploit: prevent overwriting item type on deposit

### DIFF
--- a/src/main/kotlin/net/guizhanss/infinityexpansion2/implementation/items/storage/StorageUnit.kt
+++ b/src/main/kotlin/net/guizhanss/infinityexpansion2/implementation/items/storage/StorageUnit.kt
@@ -237,7 +237,10 @@ class StorageUnit(
                 // empty storage && no item in output
                 if (cache.isEmpty() && outputItem.isAir()) return
 
-                cache.itemStack = outputItem.edit { amount(1) }
+                // Fix: only set the item type if storage is actually empty
+                if (cache.isEmpty()) {
+                    cache.itemStack = outputItem.edit { amount(1) }
+                }
 
                 for (item in pInv.storageContents) {
                     if (item.isAir() || item.isBlacklisted()) continue


### PR DESCRIPTION
## Description
This PR addresses a critical item conversion exploit in the Storage Unit.
Previously, the "Deposit" action would overwrite the stored item type based on the output slot's contents, even if the storage unit already contained a different item.

This allowed players to input cheap items (e.g., Cobblestone) via the input slot, place a valuable item in the output slot, and click "Deposit" to convert the existing Cobblestone into the valuable item.

## Proposed changes
Modified `StorageUnit.kt` inside the `InteractionMode.DEPOSIT` handler.
Added a check to ensure `cache.itemStack` (the defined item type) is only updated if the storage is currently empty (`cache.isEmpty()`).

## Related Issues (if applicable)
Fixes item conversion/duplication exploit.

## Checklist
- [x] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [x] I have also tested the proposed changes in combination with various popular addons and can confirm my changes do not break them.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
- [ ] I added sufficient Unit Tests to cover my code.